### PR TITLE
Allow newlines in templates & commands

### DIFF
--- a/src/ourthings/Queue.js
+++ b/src/ourthings/Queue.js
@@ -372,7 +372,7 @@ class Queue {
 		/*
 		 * Process any other {{}} tags but not if they have {{!}} as those are done on command exec time
 		 */
-		const commandRegex=/{{([^!|~].*?)}}/;
+		const commandRegex=/{{([^!|~](.|\n)*?)}}/;
 		while (match = commandRegex.exec(template)) {
 			if(match[1][0]==='^')
 				template = template.replace('"'+match[0]+'"', self.varsParser(match[1].substring(1,match[1].length)));
@@ -435,7 +435,7 @@ class Queue {
 	 * @return {string}
 	 */
 	templateParse(template,commands) {
-		let commandRegex=/[@\-]([a-zA-Z]*?\.[a-zA-Z0-9]*?\(.*\);)/;
+		let commandRegex=/[@\-]([a-zA-Z]*?\.[a-zA-Z0-9]*?\((.|\n)*?(\);))/;
 		let match=undefined;
 		let parentCommand;
 		let isParent;


### PR DESCRIPTION
A simple change in regex that can make things look far more readable, especially for long commands.

Allowing for template & commands to look like:
```
@templates.render({
    "targetId": "#content",
    "template": "#basic"
}, {
    "queueRun": "Instant"
});
```

Instead of being forced to stick on a single line like:
```
@templates.render({"targetId":"#content","template":"#basic"},{"queueRun":"Instant"});
```

All tests passed